### PR TITLE
i1 add unit tests for all objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,6 @@ __pycache__/
 !.vscode/tasks.json
 
 *.csv
+
+# MacOS 
+.DS_Store

--- a/src/Fls.Results.Test/ResultObjectsTests.cs
+++ b/src/Fls.Results.Test/ResultObjectsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Xunit;
 using Moq;
+using System.Threading.Tasks;
 
 namespace Fls.Results.Test
 {
@@ -22,5 +23,23 @@ namespace Fls.Results.Test
             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
             Assert.Equal(successBound, matchResult);
         }
+
+        [Fact]
+        public async void SuccessMatchAsyncTest()
+        {
+            var testValue = 2;
+            var successBound = new Mock<IOperationResult<float>>().Object;
+            var errorBound = new Mock<IOperationResult<float>>().Object;
+            var failureBound = new Mock<IOperationResult<float>>().Object;
+            Func<int, Task<IOperationResult<float>>> bindSuccess = _ => Task.FromResult(successBound);
+            Func<string, Task<IOperationResult<float>>> bindError = _ => Task.FromResult(errorBound);
+            Func<Exception, Task<IOperationResult<float>>> bindFailure = _ =>  Task.FromResult(failureBound);
+
+            var sut = new OperationResult.SuccessResult<int>(testValue);
+
+            var matchResult = await sut.MatchAsync(bindSuccess, bindError, bindFailure);
+            Assert.Equal(successBound, matchResult);
+        }
+        
     }
 }

--- a/src/Fls.Results.Test/ResultObjectsTests.cs
+++ b/src/Fls.Results.Test/ResultObjectsTests.cs
@@ -23,7 +23,40 @@ namespace Fls.Results.Test
             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
             Assert.Equal(successBound, matchResult);
         }
- 
+
+        [Fact]
+        public void ErrorMatchTest()
+        {
+            var testValue = "Error";
+            var successBound = new Mock<IOperationResult<float>>().Object;
+            var errorBound = new Mock<IOperationResult<float>>().Object;
+            var failureBound = new Mock<IOperationResult<float>>().Object;
+            Func<int, IOperationResult<float>> bindSuccess = _ => successBound;
+            Func<string, IOperationResult<float>> bindError = _ => errorBound;
+            Func<Exception, IOperationResult<float>> bindFailure = _ => failureBound;
+
+            var sut = new OperationResult.ErrorResult<int>(testValue);
+
+            var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
+            Assert.Equal(errorBound, matchResult);
+        }
+
+        [Fact]
+        public void FailureMatchTest()
+        {
+            var testValue = new Exception("Failure");
+            var successBound = new Mock<IOperationResult<float>>().Object;
+            var errorBound = new Mock<IOperationResult<float>>().Object;
+            var failureBound = new Mock<IOperationResult<float>>().Object;
+            Func<int, IOperationResult<float>> bindSuccess = _ => successBound;
+            Func<string, IOperationResult<float>> bindError = _ => errorBound;
+            Func<Exception, IOperationResult<float>> bindFailure = _ => failureBound;
+
+            var sut = new OperationResult.FailureResult<int>(testValue);
+
+            var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
+            Assert.Equal(failureBound, matchResult);
+        }
         
         [Fact]
         public async void SuccessMatchAsyncTest()

--- a/src/Fls.Results.Test/ResultObjectsTests.cs
+++ b/src/Fls.Results.Test/ResultObjectsTests.cs
@@ -23,7 +23,8 @@ namespace Fls.Results.Test
             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
             Assert.Equal(successBound, matchResult);
         }
-
+ 
+        
         [Fact]
         public async void SuccessMatchAsyncTest()
         {
@@ -39,7 +40,40 @@ namespace Fls.Results.Test
 
             var matchResult = await sut.MatchAsync(bindSuccess, bindError, bindFailure);
             Assert.Equal(successBound, matchResult);
-        }
-        
+        }  
+
+        [Fact]
+        public async void ErrorMatchAsyncTest()
+        {
+            var testValue = "Error";
+            var successBound = new Mock<IOperationResult<float>>().Object;
+            var errorBound = new Mock<IOperationResult<float>>().Object;
+            var failureBound = new Mock<IOperationResult<float>>().Object;
+            Func<int, Task<IOperationResult<float>>> bindSuccess = _ => Task.FromResult(successBound);
+            Func<string, Task<IOperationResult<float>>> bindError = _ => Task.FromResult(errorBound);
+            Func<Exception, Task<IOperationResult<float>>> bindFailure = _ =>  Task.FromResult(failureBound);
+
+            var sut = new OperationResult.ErrorResult<int>(testValue);
+
+            var matchResult = await sut.MatchAsync(bindSuccess, bindError, bindFailure);
+            Assert.Equal(errorBound, matchResult);
+        }  
+
+        [Fact]
+        public async void FailureMatchAsyncTest()
+        {
+            var testValue = new Exception("Failure");
+            var successBound = new Mock<IOperationResult<float>>().Object;
+            var errorBound = new Mock<IOperationResult<float>>().Object;
+            var failureBound = new Mock<IOperationResult<float>>().Object;
+            Func<int, Task<IOperationResult<float>>> bindSuccess = _ => Task.FromResult(successBound);
+            Func<string, Task<IOperationResult<float>>> bindError = _ => Task.FromResult(errorBound);
+            Func<Exception, Task<IOperationResult<float>>> bindFailure = _ =>  Task.FromResult(failureBound);
+
+            var sut = new OperationResult.FailureResult<int>(testValue);
+
+            var matchResult = await sut.MatchAsync(bindSuccess, bindError, bindFailure);
+            Assert.Equal(failureBound, matchResult);
+        }  
     }
 }


### PR DESCRIPTION
Closes #1 

- Test coverage for Success was earlier completed 
- Test coverage for ErrorRsult object, Match
- Test coverage for FailureRsult object, Match

Related to #4 