### PR TITLE
i1 add unit tests for all objects

### DIFF
--- a/src/Fls.Results.Test/ResultObjectsTests.cs
+++ b/src/Fls.Results.Test/ResultObjectsTests.cs
@@ -21,6 +21,40 @@ namespace Fls.Results.Test
 
             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
             Assert.Equal(successBound, matchResult);
-        }
-    }
+        }   
+
+        [Fact]
+         public void ErrorMatchTest()
+         {
+             var testValue = "Error";
+             var successBound = new Mock<IOperationResult<float>>().Object;
+             var errorBound = new Mock<IOperationResult<float>>().Object;
+             var failureBound = new Mock<IOperationResult<float>>().Object;
+             Func<int, IOperationResult<float>> bindSuccess = _ => successBound;
+             Func<string, IOperationResult<float>> bindError = _ => errorBound;
+             Func<Exception, IOperationResult<float>> bindFailure = _ => failureBound;
+
+             var sut = new OperationResult.ErrorResult<int>(testValue);
+
+             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
+             Assert.Equal(errorBound, matchResult);
+         }
+
+         [Fact]
+         public void FailureMatchTest()
+         {
+             var testValue = new Exception("Failure");
+             var successBound = new Mock<IOperationResult<float>>().Object;
+             var errorBound = new Mock<IOperationResult<float>>().Object;
+             var failureBound = new Mock<IOperationResult<float>>().Object;
+             Func<int, IOperationResult<float>> bindSuccess = _ => successBound;
+             Func<string, IOperationResult<float>> bindError = _ => errorBound;
+             Func<Exception, IOperationResult<float>> bindFailure = _ => failureBound;
+
+             var sut = new OperationResult.FailureResult<int>(testValue);
+
+             var matchResult = sut.Match(bindSuccess, bindError, bindFailure);
+             Assert.Equal(failureBound, matchResult);
+         }
+    } 
 }


### PR DESCRIPTION
Closes #1

- Test coverage for Success was earlier completed
- Test coverage for ErrorRsult object, Match
- Test coverage for FailureRsult object, Match

Related to #4 #3